### PR TITLE
refactor: add OOP private concepts

### DIFF
--- a/public/classes/space.js
+++ b/public/classes/space.js
@@ -1,14 +1,64 @@
-//Export it's necessary to export a class
 export class Space {
-    constructor(id, space, type, area, perimeter){
-        this.id = id
-        this.space = space
-        this.type = type
-        this.area = area
-        this.perimeter = perimeter
+    #id
+    #name
+    #type
+    #perimeter
+    #area
+
+    constructor(id, space, type, perimeter, area){
+        this.#id = id
+        this.#name = space
+        this.#type = type
+        this.#perimeter = perimeter
+        this.#area = area
     }
 
     toString() {
-        return `Espaço: ${this.space}, Tipo: ${this.type}, Área: ${this.area}, Perímetro: ${this.perimeter}`
+        return `Space - 
+            Id: ${this.getId()}, 
+            Name: ${this.getName()}, 
+            Type: ${this.getType()}, 
+            Perimeter: ${this.getPerimeter()}, 
+            Area: ${this.getArea()}`
+    }
+
+    getId(){
+        return this.#id
+    }
+
+    setId(id){
+        this.#id = id
+    }
+
+    getName(){
+        return this.#name
+    }
+
+    setName(name){
+        this.#name = name
+    }
+
+    getType(){
+        return this.#type
+    }
+
+    setType(type){
+        this.#type = type
+    }
+
+    getPerimeter(){
+        return this.#perimeter
+    }
+
+    setPerimeter(perimeter){
+        this.#perimeter = perimeter
+    }
+
+    getArea(){
+        return this.#area
+    }
+
+    setArea(area){
+        this.#area = area
     }
 }

--- a/public/js/spaces.js
+++ b/public/js/spaces.js
@@ -45,7 +45,7 @@ function getInputs() {
         spaceId = 0
     else{
         for (let index = 0; index < space.length; index++)
-            lastId.push(space[index].id)
+            lastId.push(space[index].getId())
             
         spaceId = Math.max(...lastId) + 1
     }
@@ -62,10 +62,10 @@ function getInputs() {
 function order() {
     //Put the vector in order considering the space name.
     space.sort((a,b) => {
-        if(a.space<b.space){
+        if(a.getName()<b.getName()){
             return -1;
         }
-        else if(a.space>b.space){
+        else if(a.getName()>b.getName()){
             return 1;
         }
         else
@@ -80,10 +80,10 @@ function order() {
 function change() {
     let selectedItem = listSpace.selectedIndex;
 
-    space[selectedItem].space = spaceInput.value;
-    space[selectedItem].type = typeInput.value;
-    space[selectedItem].area = areaInput.value;
-    space[selectedItem].perimeter = perimeterInput.value;
+    space[selectedItem].setName(spaceInput.value)
+    space[selectedItem].setType(typeInput.value)
+    space[selectedItem].setPerimeter(perimeterInput.value)
+    space[selectedItem].setArea(areaInput.value)
 
     clear();
     insertSelect();
@@ -94,7 +94,7 @@ function change() {
 //Delete the selected space
 function deleteSpace() {
     let selected = listSpace.selectedIndex;
-    let id = space[selected].id
+    let id = space[selected].getId()
 
     console.log('id: '+id)
     deleteDB(id)
@@ -109,10 +109,10 @@ function deleteSpace() {
 function selectSpace() {
     let selectedItem = listSpace.selectedIndex;
 
-    spaceInput.value = space[selectedItem].space
-    typeInput.value = space[selectedItem].type
-    areaInput.value = space[selectedItem].area
-    perimeterInput.value = space[selectedItem].perimeter
+    spaceInput.value = space[selectedItem].getName()
+    typeInput.value = space[selectedItem].getType()
+    perimeterInput.value = space[selectedItem].getPerimeter()
+    areaInput.value = space[selectedItem].getArea()
 }
 
 //Create a space list and show in the select item
@@ -125,7 +125,7 @@ function insertSelect() {
     //Create the options, and insert the content in listSpace
     for (let index = 0; index < space.length; index++) {
         option.push(document.createElement('option'));
-        option[index].innerHTML = space[index].space;
+        option[index].innerHTML = space[index].getName();
         listSpace.appendChild(option[index]);   
     }
     
@@ -154,10 +154,10 @@ function navigate(event) {
 
         if(selectedItem<0 || selectedItem>space.length-1){}
         else{
-            spaceInput.value = space[selectedItem].space
-            typeInput.value = space[selectedItem].type
-            areaInput.value = space[selectedItem].area
-            perimeterInput.value = space[selectedItem].perimeter
+            spaceInput.value = space[selectedItem].getName()
+            typeInput.value = space[selectedItem].getType()
+            perimeterInput.value = space[selectedItem].getPerimeter()
+            areaInput.value = space[selectedItem].getArea()
         }
 
         
@@ -168,12 +168,11 @@ function createDB() {
     (async()=>{
         console.log('Creating space to database')
 
-        let id = space[space.length-1].id
-        let name = space[space.length-1].space
-        let type = space[space.length-1].type
-        let perimeter = space[space.length-1].perimeter
-        let area = space[space.length-1].area
-
+        let id = space[space.length-1].getId()
+        let name = space[space.length-1].getName()
+        let type = space[space.length-1].getType()
+        let perimeter = space[space.length-1].getPerimeter()
+        let area = space[space.length-1].getArea()
 
         await fetch('/create-space',{
             method: 'POST',
@@ -211,8 +210,8 @@ function readDB(){
                 spaceDB[index].id_space, 
                 spaceDB[index].name_space, 
                 spaceDB[index].type_space, 
+                spaceDB[index].perimeter_space,
                 spaceDB[index].area_space, 
-                spaceDB[index].perimeter_space
             ));
         }
         insertSelect();
@@ -222,11 +221,11 @@ function readDB(){
 function updateDB(row){
     console.log('Updating space to database')
 
-    let id = space[row].id
-    let name = space[row].space
-    let type = space[row].type
-    let perimeter = space[row].perimeter
-    let area = space[row].area
+    let id = space[row].getId()
+    let name = space[row].getName()
+    let type = space[row].getType()
+    let perimeter = space[row].getPerimeter()
+    let area = space[row].getArea()
 
     fetch('/update-space', {
         method: 'PUT',


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Chore (documentation, packages, or tests updates, nothing that affect the final user directly)
- [ ] Release (new version of the application - only for production)

## Description
Applying the private variables concepts. However, this isn't used frequently in javascript, the new javascript functionality of # can available the private concepts. For example:
Before (just for conventional):
_car
_bus

After (works fine):
#car
#bus

## Tasks

- Update POO concepts on spaces

## Checklist

- [x] My changes have less than or equal 400 lines
- [x] I have performed a self-review of my own code
- [ ] The existing tests and linter pass locally with my changes
- [x] I have commented my code in hard-to-understand areas (if applicable)
- [ ] I have created tests for my fix or feature (if applicable)

## Dependencies

This pull request has a dependency on the following others:

- N/A